### PR TITLE
fix: improve type safety in getAllPlaces method

### DIFF
--- a/core/src/main/java/org/bigraphs/framework/core/impl/pure/PureBigraph.java
+++ b/core/src/main/java/org/bigraphs/framework/core/impl/pure/PureBigraph.java
@@ -187,10 +187,9 @@ public class PureBigraph implements Bigraph<DynamicSignature>, EcoreBigraph<Dyna
 
     @Override
     public List<BigraphEntity<?>> getAllPlaces() {
-//        return Lists.fixedSize.fromStream(Streams.<BigraphEntity<?>>concat((Stream) roots.stream(), (Stream) nodes.stream(), (Stream) sites.stream()));
         return Lists.fixedSize.<BigraphEntity<?>>ofAll((Iterable) getRoots())
-                .withAll(getNodes())
-                .withAll(getSites());
+                .withAll((Iterable<? extends BigraphEntity<?>>) (Iterable<?>) getNodes())
+                .withAll((Iterable<? extends BigraphEntity<?>>) (Iterable<?>) getSites());
     }
 
     @Override


### PR DESCRIPTION
- Updated getAllPlaces method to ensure proper type casting for nodes and sites, enhancing type safety and reducing potential runtime errors.